### PR TITLE
Windows 10 April 2018 Update SDK (17134)

### DIFF
--- a/D3D12Test/D3D12Test_Desktop_2017_Win10.vcxproj
+++ b/D3D12Test/D3D12Test_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <RootNamespace>D3D12Test</RootNamespace>
     <ProjectGuid>{f99e4e44-9746-4763-bd3a-bddfde58a4d1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/D3D12Test/D3D12Test_Windows10.vcxproj
+++ b/D3D12Test/D3D12Test_Windows10.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/EffectsTest/EffectsTest_Desktop_2017_Win10.vcxproj
+++ b/EffectsTest/EffectsTest_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <RootNamespace>EffectsTest</RootNamespace>
     <ProjectGuid>{25a385f0-3ec3-47fc-b582-bdffc856b580}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/EffectsTest/EffectsTest_Windows10.vcxproj
+++ b/EffectsTest/EffectsTest_Windows10.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/HDRTest/HDRTest_Desktop_2017_Win10.vcxproj
+++ b/HDRTest/HDRTest_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <RootNamespace>HDRTest</RootNamespace>
     <ProjectGuid>{74eac58e-732a-437f-b77c-41b2495932ec}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/HDRTest/HDRTest_Windows10.vcxproj
+++ b/HDRTest/HDRTest_Windows10.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/LoadTest/LoadTest_Desktop_2017_Win10.vcxproj
+++ b/LoadTest/LoadTest_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <RootNamespace>LoadTest</RootNamespace>
     <ProjectGuid>{3ffd498c-90a1-45fe-8232-dd653d216b03}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/LoadTest/LoadTest_Windows10.vcxproj
+++ b/LoadTest/LoadTest_Windows10.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/ModelTest/ModelTest_Desktop_2017_Win10.vcxproj
+++ b/ModelTest/ModelTest_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <RootNamespace>ModelTest</RootNamespace>
     <ProjectGuid>{836bf98c-d429-434e-accc-6460a1c20e09}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ModelTest/ModelTest_Windows10.vcxproj
+++ b/ModelTest/ModelTest_Windows10.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/ModelTest/WaveFrontReader.h
+++ b/ModelTest/WaveFrontReader.h
@@ -5,12 +5,8 @@
 //
 // http://en.wikipedia.org/wiki/Wavefront_.obj_file
 //
-// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF
-// ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO
-// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
-// PARTICULAR PURPOSE.
-//
 // Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 //
 // http://go.microsoft.com/fwlink/?LinkID=324981
 //--------------------------------------------------------------------------------------
@@ -54,9 +50,9 @@ public:
         DirectX::XMFLOAT2 textureCoordinate;
     };
 
-    WaveFrontReader() : hasNormals(false), hasTexcoords(false) {}
+    WaveFrontReader() noexcept : hasNormals(false), hasTexcoords(false) {}
 
-    HRESULT Load( _In_z_ const wchar_t* szFileName, bool ccw = true )
+    HRESULT Load(_In_z_ const wchar_t* szFileName, bool ccw = true)
     {
         Clear();
 
@@ -64,12 +60,12 @@ public:
 
         using namespace DirectX;
 
-        std::wifstream InFile( szFileName );
-        if( !InFile )
-            return HRESULT_FROM_WIN32( ERROR_FILE_NOT_FOUND );
+        std::wifstream InFile(szFileName);
+        if (!InFile)
+            return HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
 
         wchar_t fname[_MAX_FNAME] = {};
-        _wsplitpath_s( szFileName, nullptr, 0, nullptr, 0, fname, _MAX_FNAME, nullptr, 0 );
+        _wsplitpath_s(szFileName, nullptr, 0, nullptr, 0, fname, _MAX_FNAME, nullptr, 0);
 
         name = fname;
 
@@ -81,77 +77,77 @@ public:
 
         Material defmat;
 
-        wcscpy_s( defmat.strName, L"default" );
-        materials.emplace_back( defmat );
+        wcscpy_s(defmat.strName, L"default");
+        materials.emplace_back(defmat);
 
         uint32_t curSubset = 0;
 
         wchar_t strMaterialFilename[MAX_PATH] = {};
-        for( ;; )
+        for (;; )
         {
             std::wstring strCommand;
             InFile >> strCommand;
-            if( !InFile )
+            if (!InFile)
                 break;
 
-            if ( *strCommand.c_str() == L'#' )
+            if (*strCommand.c_str() == L'#')
             {
                 // Comment
             }
-            else if( 0 == wcscmp( strCommand.c_str(), L"o" ) )
+            else if (0 == wcscmp(strCommand.c_str(), L"o"))
             {
                 // Object name ignored
             }
-            else if( 0 == wcscmp( strCommand.c_str(), L"g" ) )
+            else if (0 == wcscmp(strCommand.c_str(), L"g"))
             {
                 // Group name ignored
             }
-            else if( 0 == wcscmp( strCommand.c_str(), L"s" ) )
+            else if (0 == wcscmp(strCommand.c_str(), L"s"))
             {
                 // Smoothing group ignored
             }
-            else if( 0 == wcscmp( strCommand.c_str(), L"v" ) )
+            else if (0 == wcscmp(strCommand.c_str(), L"v"))
             {
                 // Vertex Position
                 float x, y, z;
                 InFile >> x >> y >> z;
-                positions.emplace_back( XMFLOAT3( x, y, z ) );
+                positions.emplace_back(XMFLOAT3(x, y, z));
             }
-            else if( 0 == wcscmp( strCommand.c_str(), L"vt" ) )
+            else if (0 == wcscmp(strCommand.c_str(), L"vt"))
             {
                 // Vertex TexCoord
                 float u, v;
                 InFile >> u >> v;
-                texCoords.emplace_back( XMFLOAT2( u, v ) );
+                texCoords.emplace_back(XMFLOAT2(u, v));
 
                 hasTexcoords = true;
             }
-            else if( 0 == wcscmp( strCommand.c_str(), L"vn" ) )
+            else if (0 == wcscmp(strCommand.c_str(), L"vn"))
             {
                 // Vertex Normal
                 float x, y, z;
                 InFile >> x >> y >> z;
-                normals.emplace_back( XMFLOAT3( x, y, z ) );
+                normals.emplace_back(XMFLOAT3(x, y, z));
 
                 hasNormals = true;
             }
-            else if( 0 == wcscmp( strCommand.c_str(), L"f" ) )
+            else if (0 == wcscmp(strCommand.c_str(), L"f"))
             {
                 // Face
                 INT iPosition, iTexCoord, iNormal;
                 Vertex vertex;
 
-                DWORD faceIndex[ MAX_POLY ];
+                DWORD faceIndex[MAX_POLY];
                 size_t iFace = 0;
-                for(;;)
+                for (;;)
                 {
-                    if ( iFace >= MAX_POLY )
+                    if (iFace >= MAX_POLY)
                     {
                         // Too many polygon verts for the reader
                         return E_FAIL;
                     }
 
-                    memset( &vertex, 0, sizeof( vertex ) );
+                    memset(&vertex, 0, sizeof(vertex));
 
                     InFile >> iPosition;
 
@@ -177,11 +173,11 @@ public:
 
                     vertex.position = positions[vertexIndex];
 
-                    if( '/' == InFile.peek() )
+                    if ('/' == InFile.peek())
                     {
                         InFile.ignore();
 
-                        if( '/' != InFile.peek() )
+                        if ('/' != InFile.peek())
                         {
                             // Optional texture coordinate
                             InFile >> iTexCoord;
@@ -209,7 +205,7 @@ public:
                             vertex.textureCoordinate = texCoords[coordIndex];
                         }
 
-                        if( '/' == InFile.peek() )
+                        if ('/' == InFile.peek())
                         {
                             InFile.ignore();
 
@@ -244,48 +240,48 @@ public:
                     // list. Store the index in the Indices array. The Vertices and Indices
                     // lists will eventually become the Vertex Buffer and Index Buffer for
                     // the mesh.
-                    DWORD index = AddVertex( vertexIndex, &vertex, vertexCache );
-                    if ( index == (DWORD)-1 )
-                       return E_OUTOFMEMORY;
+                    DWORD index = AddVertex(vertexIndex, &vertex, vertexCache);
+                    if (index == (DWORD)-1)
+                        return E_OUTOFMEMORY;
 
 #pragma warning( suppress : 4127 )
-                    if ( sizeof(index_t) == 2 && ( index >= 0xFFFF ) )
+                    if (sizeof(index_t) == 2 && (index >= 0xFFFF))
                     {
                         // Too many indices for 16-bit IB!
                         return E_FAIL;
                     }
 #pragma warning( suppress : 4127 )
-                    else if ( sizeof(index_t) == 4 && ( index >= 0xFFFFFFFF ) )
+                    else if (sizeof(index_t) == 4 && (index >= 0xFFFFFFFF))
                     {
                         // Too many indices for 32-bit IB!
                         return E_FAIL;
                     }
 
-                    faceIndex[ iFace ] = index;
+                    faceIndex[iFace] = index;
                     ++iFace;
-   
+
                     // Check for more face data or end of the face statement
                     bool faceEnd = false;
-                    for(;;)
+                    for (;;)
                     {
                         wchar_t p = InFile.peek();
-                    
-                        if ( '\n' == p || !InFile )
+
+                        if ('\n' == p || !InFile)
                         {
                             faceEnd = true;
                             break;
                         }
-                        else if ( isdigit( p ) || p == '-' || p == '+' )
+                        else if (isdigit(p) || p == '-' || p == '+')
                             break;
 
                         InFile.ignore();
                     }
 
-                    if ( faceEnd )
+                    if (faceEnd)
                         break;
                 }
 
-                if ( iFace < 3 )
+                if (iFace < 3)
                 {
                     // Need at least 3 points to form a triangle
                     return E_FAIL;
@@ -295,34 +291,34 @@ public:
                 DWORD i0 = faceIndex[0];
                 DWORD i1 = faceIndex[1];
 
-                for( size_t j = 2; j < iFace; ++ j )
+                for (size_t j = 2; j < iFace; ++j)
                 {
-                    DWORD index = faceIndex[ j ];
-                    indices.emplace_back( static_cast<index_t>( i0 ) );
-                    if ( ccw )
+                    DWORD index = faceIndex[j];
+                    indices.emplace_back(static_cast<index_t>(i0));
+                    if (ccw)
                     {
-                        indices.emplace_back( static_cast<index_t>( i1 ) );
-                        indices.emplace_back( static_cast<index_t>( index ) );
+                        indices.emplace_back(static_cast<index_t>(i1));
+                        indices.emplace_back(static_cast<index_t>(index));
                     }
                     else
                     {
-                        indices.emplace_back( static_cast<index_t>( index ) );
-                        indices.emplace_back( static_cast<index_t>( i1 ) );
-                    }                        
-                     
-                    attributes.emplace_back( curSubset );
+                        indices.emplace_back(static_cast<index_t>(index));
+                        indices.emplace_back(static_cast<index_t>(i1));
+                    }
+
+                    attributes.emplace_back(curSubset);
 
                     i1 = index;
                 }
 
-                assert( attributes.size()*3 == indices.size() );
+                assert(attributes.size() * 3 == indices.size());
             }
-            else if( 0 == wcscmp( strCommand.c_str(), L"mtllib" ) )
+            else if (0 == wcscmp(strCommand.c_str(), L"mtllib"))
             {
                 // Material library
                 InFile >> strMaterialFilename;
             }
-            else if( 0 == wcscmp( strCommand.c_str(), L"usemtl" ) )
+            else if (0 == wcscmp(strCommand.c_str(), L"usemtl"))
             {
                 // Material
                 wchar_t strName[MAX_PATH] = {};
@@ -330,9 +326,9 @@ public:
 
                 bool bFound = false;
                 uint32_t count = 0;
-                for( auto it = materials.cbegin(); it != materials.cend(); ++it, ++count )
+                for (auto it = materials.cbegin(); it != materials.cend(); ++it, ++count)
                 {
-                    if( 0 == wcscmp( it->strName, strName ) )
+                    if (0 == wcscmp(it->strName, strName))
                     {
                         bFound = true;
                         curSubset = count;
@@ -340,23 +336,23 @@ public:
                     }
                 }
 
-                if( !bFound )
+                if (!bFound)
                 {
                     Material mat;
-                    curSubset = static_cast<uint32_t>( materials.size() );
-                    wcscpy_s( mat.strName, MAX_PATH - 1, strName );
-                    materials.emplace_back( mat );
+                    curSubset = static_cast<uint32_t>(materials.size());
+                    wcscpy_s(mat.strName, MAX_PATH - 1, strName);
+                    materials.emplace_back(mat);
                 }
             }
             else
             {
 #ifdef _DEBUG
                 // Unimplemented or unrecognized command
-                OutputDebugStringW( strCommand.c_str());
+                OutputDebugStringW(strCommand.c_str());
 #endif
             }
 
-            InFile.ignore( 1000, '\n' );
+            InFile.ignore(1000, '\n');
         }
 
         if (positions.empty())
@@ -365,55 +361,57 @@ public:
         // Cleanup
         InFile.close();
 
-        BoundingBox::CreateFromPoints( bounds, positions.size(), positions.data(), sizeof(XMFLOAT3) );
+        BoundingBox::CreateFromPoints(bounds, positions.size(), positions.data(), sizeof(XMFLOAT3));
 
         // If an associated material file was found, read that in as well.
-        if( *strMaterialFilename )
+        if (*strMaterialFilename)
         {
             wchar_t ext[_MAX_EXT] = {};
-            _wsplitpath_s( strMaterialFilename, nullptr, 0, nullptr, 0, fname, _MAX_FNAME, ext, _MAX_EXT );
+            _wsplitpath_s(strMaterialFilename, nullptr, 0, nullptr, 0, fname, _MAX_FNAME, ext, _MAX_EXT);
 
             wchar_t drive[_MAX_DRIVE] = {};
             wchar_t dir[_MAX_DIR] = {};
-            _wsplitpath_s( szFileName, drive, _MAX_DRIVE, dir, _MAX_DIR, nullptr, 0, nullptr, 0 );
+            _wsplitpath_s(szFileName, drive, _MAX_DRIVE, dir, _MAX_DIR, nullptr, 0, nullptr, 0);
 
-            wchar_t szPath[ MAX_PATH ] = {};
-            _wmakepath_s( szPath, MAX_PATH, drive, dir, fname, ext );
+            wchar_t szPath[MAX_PATH] = {};
+            _wmakepath_s(szPath, MAX_PATH, drive, dir, fname, ext);
 
-            HRESULT hr = LoadMTL( szPath );
-            if ( FAILED(hr) )
+            HRESULT hr = LoadMTL(szPath);
+            if (FAILED(hr))
                 return hr;
         }
 
         return S_OK;
     }
 
-    HRESULT LoadMTL( _In_z_ const wchar_t* szFileName )
+    HRESULT LoadMTL(_In_z_ const wchar_t* szFileName)
     {
+        using namespace DirectX;
+
         // Assumes MTL is in CWD along with OBJ
-        std::wifstream InFile( szFileName );
-        if( !InFile )
-            return HRESULT_FROM_WIN32( ERROR_FILE_NOT_FOUND );
+        std::wifstream InFile(szFileName);
+        if (!InFile)
+            return HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
 
         auto curMaterial = materials.end();
 
-        for( ;; )
+        for (;; )
         {
             std::wstring strCommand;
             InFile >> strCommand;
-            if( !InFile )
+            if (!InFile)
                 break;
 
-            if( 0 == wcscmp( strCommand.c_str(), L"newmtl" ) )
+            if (0 == wcscmp(strCommand.c_str(), L"newmtl"))
             {
                 // Switching active materials
                 wchar_t strName[MAX_PATH] = {};
                 InFile >> strName;
 
                 curMaterial = materials.end();
-                for( auto it = materials.begin(); it != materials.end(); ++it )
+                for (auto it = materials.begin(); it != materials.end(); ++it)
                 {
-                    if( 0 == wcscmp( it->strName, strName ) )
+                    if (0 == wcscmp(it->strName, strName))
                     {
                         curMaterial = it;
                         break;
@@ -422,55 +420,55 @@ public:
             }
 
             // The rest of the commands rely on an active material
-            if( curMaterial == materials.end() )
+            if (curMaterial == materials.end())
                 continue;
 
-            if( 0 == wcscmp( strCommand.c_str(), L"#" ) )
+            if (0 == wcscmp(strCommand.c_str(), L"#"))
             {
                 // Comment
             }
-            else if( 0 == wcscmp( strCommand.c_str(), L"Ka" ) )
+            else if (0 == wcscmp(strCommand.c_str(), L"Ka"))
             {
                 // Ambient color
                 float r, g, b;
                 InFile >> r >> g >> b;
-                curMaterial->vAmbient = XMFLOAT3( r, g, b );
+                curMaterial->vAmbient = XMFLOAT3(r, g, b);
             }
-            else if( 0 == wcscmp( strCommand.c_str(), L"Kd" ) )
+            else if (0 == wcscmp(strCommand.c_str(), L"Kd"))
             {
                 // Diffuse color
                 float r, g, b;
                 InFile >> r >> g >> b;
-                curMaterial->vDiffuse = XMFLOAT3( r, g, b );
+                curMaterial->vDiffuse = XMFLOAT3(r, g, b);
             }
-            else if( 0 == wcscmp( strCommand.c_str(), L"Ks" ) )
+            else if (0 == wcscmp(strCommand.c_str(), L"Ks"))
             {
                 // Specular color
                 float r, g, b;
                 InFile >> r >> g >> b;
-                curMaterial->vSpecular = XMFLOAT3( r, g, b );
+                curMaterial->vSpecular = XMFLOAT3(r, g, b);
             }
-            else if( 0 == wcscmp( strCommand.c_str(), L"d" ) ||
-                     0 == wcscmp( strCommand.c_str(), L"Tr" ) )
+            else if (0 == wcscmp(strCommand.c_str(), L"d") ||
+                0 == wcscmp(strCommand.c_str(), L"Tr"))
             {
                 // Alpha
                 InFile >> curMaterial->fAlpha;
             }
-            else if( 0 == wcscmp( strCommand.c_str(), L"Ns" ) )
+            else if (0 == wcscmp(strCommand.c_str(), L"Ns"))
             {
                 // Shininess
                 int nShininess;
                 InFile >> nShininess;
                 curMaterial->nShininess = nShininess;
             }
-            else if( 0 == wcscmp( strCommand.c_str(), L"illum" ) )
+            else if (0 == wcscmp(strCommand.c_str(), L"illum"))
             {
                 // Specular on/off
                 int illumination;
                 InFile >> illumination;
-                curMaterial->bSpecular = ( illumination == 2 );
+                curMaterial->bSpecular = (illumination == 2);
             }
-            else if( 0 == wcscmp( strCommand.c_str(), L"map_Kd" ) )
+            else if (0 == wcscmp(strCommand.c_str(), L"map_Kd"))
             {
                 // Texture
                 InFile >> curMaterial->strTexture;
@@ -480,7 +478,7 @@ public:
                 // Unimplemented or unrecognized command
             }
 
-            InFile.ignore( 1000, L'\n' );
+            InFile.ignore(1000, L'\n');
         }
 
         InFile.close();
@@ -502,59 +500,59 @@ public:
         bounds.Extents.x = bounds.Extents.y = bounds.Extents.z = 0.f;
     }
 
-    HRESULT LoadVBO( _In_z_ const wchar_t* szFileName )
+    HRESULT LoadVBO(_In_z_ const wchar_t* szFileName)
     {
         Clear();
 
         wchar_t fname[_MAX_FNAME] = {};
-        _wsplitpath_s( szFileName, nullptr, 0, nullptr, 0, fname, _MAX_FNAME, nullptr, 0 );
+        _wsplitpath_s(szFileName, nullptr, 0, nullptr, 0, fname, _MAX_FNAME, nullptr, 0);
 
         name = fname;
 
         Material defmat;
-        wcscpy_s( defmat.strName, L"default" );
-        materials.emplace_back( defmat );
+        wcscpy_s(defmat.strName, L"default");
+        materials.emplace_back(defmat);
 
         std::ifstream vboFile(szFileName, std::ifstream::in | std::ifstream::binary);
-        if ( !vboFile.is_open() )
-            return HRESULT_FROM_WIN32( ERROR_FILE_NOT_FOUND );
+        if (!vboFile.is_open())
+            return HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
 
         hasNormals = hasTexcoords = true;
 
         uint32_t numVertices = 0;
         uint32_t numIndices = 0;
 
-        vboFile.read( reinterpret_cast<char*>( &numVertices ), sizeof(uint32_t ) );
-        if ( !numVertices )
+        vboFile.read(reinterpret_cast<char*>(&numVertices), sizeof(uint32_t));
+        if (!numVertices)
             return E_FAIL;
 
-        vboFile.read( reinterpret_cast<char*>( &numIndices ), sizeof(uint32_t ) );
-        if ( !numIndices )
+        vboFile.read(reinterpret_cast<char*>(&numIndices), sizeof(uint32_t));
+        if (!numIndices)
             return E_FAIL;
 
-        vertices.resize( numVertices );
-        vboFile.read( reinterpret_cast<char*>( vertices.data() ), sizeof(Vertex) * numVertices );
+        vertices.resize(numVertices);
+        vboFile.read(reinterpret_cast<char*>(vertices.data()), sizeof(Vertex) * numVertices);
 
 #pragma warning( suppress : 4127 )
-        if ( sizeof( index_t ) == 2 )
+        if (sizeof(index_t) == 2)
         {
-            indices.resize( numIndices );
-            vboFile.read( reinterpret_cast<char*>( indices.data() ), sizeof(uint16_t) * numIndices );
+            indices.resize(numIndices);
+            vboFile.read(reinterpret_cast<char*>(indices.data()), sizeof(uint16_t) * numIndices);
         }
         else
         {
             std::vector<uint16_t> tmp;
-            tmp.resize( numIndices );
-            vboFile.read( reinterpret_cast<char*>( tmp.data() ), sizeof(uint16_t) * numIndices );
+            tmp.resize(numIndices);
+            vboFile.read(reinterpret_cast<char*>(tmp.data()), sizeof(uint16_t) * numIndices);
 
-            indices.reserve( numIndices );
-            for( auto it = tmp.cbegin(); it != tmp.cend(); ++it )
+            indices.reserve(numIndices);
+            for (auto it = tmp.cbegin(); it != tmp.cend(); ++it)
             {
-                indices.emplace_back( *it );
+                indices.emplace_back(*it);
             }
         }
 
-        BoundingBox::CreateFromPoints( bounds, vertices.size(), reinterpret_cast<const XMFLOAT3*>( vertices.data() ), sizeof(Vertex) );
+        BoundingBox::CreateFromPoints(bounds, vertices.size(), reinterpret_cast<const XMFLOAT3*>(vertices.data()), sizeof(Vertex));
 
         vboFile.close();
 
@@ -574,14 +572,17 @@ public:
         wchar_t strName[MAX_PATH];
         wchar_t strTexture[MAX_PATH];
 
-        Material() :
-            vAmbient( 0.2f, 0.2f, 0.2f ),
-            vDiffuse( 0.8f, 0.8f, 0.8f ),
-            vSpecular( 1.0f, 1.0f, 1.0f ),
-            nShininess( 0 ),
-            fAlpha( 1.f ),
-            bSpecular( false )
-            { memset(strName, 0, sizeof(strName)); memset(strTexture, 0, sizeof(strTexture)); } 
+        Material() noexcept :
+        vAmbient(0.2f, 0.2f, 0.2f),
+            vDiffuse(0.8f, 0.8f, 0.8f),
+            vSpecular(1.0f, 1.0f, 1.0f),
+            nShininess(0),
+            fAlpha(1.f),
+            bSpecular(false),
+            strName{},
+            strTexture{}
+        {
+        }
     };
 
     std::vector<Vertex>     vertices;
@@ -598,25 +599,25 @@ public:
 private:
     typedef std::unordered_multimap<UINT, UINT> VertexCache;
 
-    DWORD AddVertex( UINT hash, Vertex* pVertex, VertexCache& cache )
+    DWORD AddVertex(UINT hash, Vertex* pVertex, VertexCache& cache)
     {
-        auto f = cache.equal_range( hash );
+        auto f = cache.equal_range(hash);
 
-        for( auto it = f.first; it != f.second; ++it )
+        for (auto it = f.first; it != f.second; ++it)
         {
-            auto& tv = vertices[ it->second ];
+            auto& tv = vertices[it->second];
 
-            if ( 0 == memcmp( pVertex, &tv, sizeof(Vertex) ) )
+            if (0 == memcmp(pVertex, &tv, sizeof(Vertex)))
             {
                 return it->second;
             }
         }
 
-        DWORD index = static_cast<UINT>( vertices.size() );
-        vertices.emplace_back( *pVertex );
+        DWORD index = static_cast<UINT>(vertices.size());
+        vertices.emplace_back(*pVertex);
 
-        VertexCache::value_type entry( hash, index );
-        cache.insert( entry );
+        VertexCache::value_type entry(hash, index);
+        cache.insert(entry);
         return index;
     }
 };

--- a/PBRTest/Game.cpp
+++ b/PBRTest/Game.cpp
@@ -79,7 +79,7 @@ namespace
 
         auto hdr = reinterpret_cast<const VBO::header_t*>(blob.data());
 
-        if (!hdr->numIndices || !hdr->numIndices)
+        if (!hdr->numIndices || !hdr->numVertices)
             throw std::exception("ReadVBO");
 
         static_assert(sizeof(VertexPositionNormalTexture) == 32, "VBO vertex size mismatch");

--- a/PBRTest/PBRTest_Desktop_2017_Win10.vcxproj
+++ b/PBRTest/PBRTest_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <RootNamespace>PBRTest</RootNamespace>
     <ProjectGuid>{9b069e2c-0c27-437b-b5ff-91d46f8e9691}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/PBRTest/PBRTest_Windows10.vcxproj
+++ b/PBRTest/PBRTest_Windows10.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/PostProcessTest/PostProcessTest_Desktop_2017_Win10.vcxproj
+++ b/PostProcessTest/PostProcessTest_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <RootNamespace>PostProcessTest</RootNamespace>
     <ProjectGuid>{499dfb34-5133-4904-9fe0-84cde1bae234}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/PostProcessTest/PostProcessTest_Windows10.vcxproj
+++ b/PostProcessTest/PostProcessTest_Windows10.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/PrimitivesTest/PrimitivesTest_Desktop_2017_Win10.vcxproj
+++ b/PrimitivesTest/PrimitivesTest_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <RootNamespace>PrimitivesTest</RootNamespace>
     <ProjectGuid>{8c0828a9-2745-460e-8499-68940509bf70}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/PrimitivesTest/PrimitivesTest_Windows10.vcxproj
+++ b/PrimitivesTest/PrimitivesTest_Windows10.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/ShaderTest/ShaderTest_Desktop_2017_Win10.vcxproj
+++ b/ShaderTest/ShaderTest_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <RootNamespace>ShaderTest</RootNamespace>
     <ProjectGuid>{3ce15a64-d1bb-4ebf-93bd-bda32f318ba2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ShaderTest/ShaderTest_Windows10.vcxproj
+++ b/ShaderTest/ShaderTest_Windows10.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/SpriteBatchTest/SpriteBatchTest_Desktop_2017_Win10.vcxproj
+++ b/SpriteBatchTest/SpriteBatchTest_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <RootNamespace>SpriteBatchTest</RootNamespace>
     <ProjectGuid>{6ce3aba9-a541-449d-aa72-71c88cf3cd85}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/SpriteBatchTest/SpriteBatchTest_Windows10.vcxproj
+++ b/SpriteBatchTest/SpriteBatchTest_Windows10.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/SpriteFontTest/SpriteFontTest_Desktop_2017_Win10.vcxproj
+++ b/SpriteFontTest/SpriteFontTest_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <RootNamespace>SpriteFontTest</RootNamespace>
     <ProjectGuid>{0c9f8d27-71db-449c-bab2-69ee02abbfe7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/SpriteFontTest/SpriteFontTest_Windows10.vcxproj
+++ b/SpriteFontTest/SpriteFontTest_Windows10.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/fuzzloaders/fuzzloaders_Desktop_2017_Win10.vcxproj
+++ b/fuzzloaders/fuzzloaders_Desktop_2017_Win10.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{65A50BAD-23BA-426B-9D72-2BD06F31F13B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>fuzzloaders</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Updated VS 2017 projects to use the Windows 10 SDK (17134) which requires the VS 2017 (15.7 update)

> The VS 2017 Xbox One XDK projects still support older versions of VS 2017 because they don't use the Windows 10 SDK

Also, the PC versions of the test suite now accept ``-minpower`` command-line switch to prefer use of ``DXGI_GPU_PREFERENCE_MINIMUM_POWER`` devices rather than the default ``DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE``. Typically on hybrid systems running Windows 10 (17134) this will result in using an Intel device rather than an AMD/NVIDIA device.