### PR TITLE
Model::LoadStaticBuffers to use static VB/IB instead of dynamic 

### DIFF
--- a/ModelTest/Game.cpp
+++ b/ModelTest/Game.cpp
@@ -767,6 +767,11 @@ void Game::CreateDeviceDependentResources()
         CreateShaderResourceView(device, m_cubemap.Get(), m_resourceDescriptors->GetCpuHandle(StaticDescriptors::Cubemap), iscubemap);
     }
 
+    // Optimize some models
+    m_cup->LoadBuffers(device, resourceUpload);
+    m_cupMesh->LoadBuffers(device, resourceUpload);
+    m_vbo->LoadBuffers(device, resourceUpload);
+
     auto uploadResourcesFinished = resourceUpload.End(m_deviceResources->GetCommandQueue());
 
     uploadResourcesFinished.wait();

--- a/ModelTest/Game.cpp
+++ b/ModelTest/Game.cpp
@@ -768,9 +768,23 @@ void Game::CreateDeviceDependentResources()
     }
 
     // Optimize some models
-    m_cup->LoadBuffers(device, resourceUpload);
-    m_cupMesh->LoadBuffers(device, resourceUpload);
-    m_vbo->LoadBuffers(device, resourceUpload);
+    assert(!m_cupMesh->meshes[0]->opaqueMeshParts[0]->staticVertexBuffer);
+    assert(!m_cup->meshes[0]->opaqueMeshParts[0]->staticIndexBuffer);
+    m_cup->LoadStaticBuffers(device, resourceUpload);
+    assert(m_cup->meshes[0]->opaqueMeshParts[0]->staticVertexBuffer && !m_cup->meshes[0]->opaqueMeshParts[0]->vertexBuffer);
+    assert(m_cup->meshes[0]->opaqueMeshParts[0]->staticIndexBuffer && !m_cup->meshes[0]->opaqueMeshParts[0]->indexBuffer);
+
+    assert(!m_cupMesh->meshes[0]->opaqueMeshParts[0]->staticVertexBuffer);
+    assert(!m_cupMesh->meshes[0]->opaqueMeshParts[0]->staticIndexBuffer);
+    m_cupMesh->LoadStaticBuffers(device, resourceUpload);
+    assert(m_cupMesh->meshes[0]->opaqueMeshParts[0]->staticVertexBuffer && !m_cupMesh->meshes[0]->opaqueMeshParts[0]->vertexBuffer);
+    assert(m_cupMesh->meshes[0]->opaqueMeshParts[0]->staticIndexBuffer && !m_cupMesh->meshes[0]->opaqueMeshParts[0]->indexBuffer);
+
+    assert(!m_vbo->meshes[0]->opaqueMeshParts[0]->staticVertexBuffer);
+    assert(!m_vbo->meshes[0]->opaqueMeshParts[0]->staticIndexBuffer);
+    m_vbo->LoadStaticBuffers(device, resourceUpload, true);
+    assert(m_vbo->meshes[0]->opaqueMeshParts[0]->staticVertexBuffer && m_vbo->meshes[0]->opaqueMeshParts[0]->vertexBuffer);
+    assert(m_vbo->meshes[0]->opaqueMeshParts[0]->staticIndexBuffer && m_vbo->meshes[0]->opaqueMeshParts[0]->indexBuffer);
 
     auto uploadResourcesFinished = resourceUpload.End(m_deviceResources->GetCommandQueue());
 

--- a/ModelTest/Game.cpp
+++ b/ModelTest/Game.cpp
@@ -768,7 +768,7 @@ void Game::CreateDeviceDependentResources()
     }
 
     // Optimize some models
-    assert(!m_cupMesh->meshes[0]->opaqueMeshParts[0]->staticVertexBuffer);
+    assert(!m_cup->meshes[0]->opaqueMeshParts[0]->staticVertexBuffer);
     assert(!m_cup->meshes[0]->opaqueMeshParts[0]->staticIndexBuffer);
     m_cup->LoadStaticBuffers(device, resourceUpload);
     assert(m_cup->meshes[0]->opaqueMeshParts[0]->staticVertexBuffer && !m_cup->meshes[0]->opaqueMeshParts[0]->vertexBuffer);

--- a/ModelTest/ModelLoadOBJ.cpp
+++ b/ModelTest/ModelLoadOBJ.cpp
@@ -196,7 +196,9 @@ std::unique_ptr<Model> CreateModelFromOBJ(_In_z_ const wchar_t* szFileName)
             part->startIndex = static_cast<uint32_t>(sindex);
             part->vertexStride = static_cast<uint32_t>(sizeof(VertexPositionNormalTexture));
 
+            part->indexBufferSize = static_cast<uint32_t>(indexSize);
             part->indexBuffer = ib;
+            part->vertexBufferSize = static_cast<uint32_t>(vertSize);
             part->vertexBuffer = vb;
             part->materialIndex = matIndex;
             part->vbDecl = g_vbdecl;


### PR DESCRIPTION
Test for validating changes to Model for static VB/IBs in [this pull request](https://github.com/Microsoft/DirectXTK12/pull/38)