### PR TITLE
Cleaned up tests for clang/LLVM conformance

### DIFF
--- a/Audio3DTest/Game.cpp
+++ b/Audio3DTest/Game.cpp
@@ -32,15 +32,15 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const X3DAUDIO_CONE Listener_DirectionalCone = { X3DAUDIO_PI * 5.0f / 6.0f, X3DAUDIO_PI * 11.0f / 6.0f, 1.0f, 0.75f, 0.0f, 0.25f, 0.708f, 1.0f };
+    constexpr X3DAUDIO_CONE Listener_DirectionalCone = { X3DAUDIO_PI * 5.0f / 6.0f, X3DAUDIO_PI * 11.0f / 6.0f, 1.0f, 0.75f, 0.0f, 0.25f, 0.708f, 1.0f };
 
-    const X3DAUDIO_CONE Emitter_DirectionalCone = { 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f, 1.f };
+    constexpr X3DAUDIO_CONE Emitter_DirectionalCone = { 0.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f, 1.f };
 
-    const X3DAUDIO_DISTANCE_CURVE_POINT Emitter_LFE_CurvePoints[3] = { 0.0f, 1.0f, 0.25f, 0.0f, 1.0f, 0.0f };
-    const X3DAUDIO_DISTANCE_CURVE       Emitter_LFE_Curve = { (X3DAUDIO_DISTANCE_CURVE_POINT*)&Emitter_LFE_CurvePoints[0], 3 };
+    constexpr X3DAUDIO_DISTANCE_CURVE_POINT Emitter_LFE_CurvePoints[3] = { { 0.0f, 1.0f }, { 0.25f, 0.0f }, { 1.0f, 0.0f } };
+    constexpr X3DAUDIO_DISTANCE_CURVE       Emitter_LFE_Curve = { (X3DAUDIO_DISTANCE_CURVE_POINT*)&Emitter_LFE_CurvePoints[0], 3 };
 
-    const X3DAUDIO_DISTANCE_CURVE_POINT Emitter_Reverb_CurvePoints[3] = { 0.0f, 0.5f, 0.75f, 1.0f, 1.0f, 0.0f };
-    const X3DAUDIO_DISTANCE_CURVE       Emitter_Reverb_Curve = { (X3DAUDIO_DISTANCE_CURVE_POINT*)&Emitter_Reverb_CurvePoints[0], 3 };
+    constexpr X3DAUDIO_DISTANCE_CURVE_POINT Emitter_Reverb_CurvePoints[3] = { { 0.0f, 0.5f }, { 0.75f, 1.0f }, { 1.0f, 0.0f } };
+    constexpr X3DAUDIO_DISTANCE_CURVE       Emitter_Reverb_Curve = { (X3DAUDIO_DISTANCE_CURVE_POINT*)&Emitter_Reverb_CurvePoints[0], 3 };
 
     void SetDeviceString(_In_ AudioEngine* engine, _Out_writes_(maxsize) wchar_t* deviceStr, size_t maxsize)
     {
@@ -517,7 +517,7 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 cameraPosition = { 0, 14, 0 };
+    static const XMVECTORF32 cameraPosition = { { { 0.f, 14.f, 0.f, 0.f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;

--- a/Audio3DTest/pch.h
+++ b/Audio3DTest/pch.h
@@ -27,6 +27,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -35,6 +41,10 @@
 #define NOSERVICE
 #define NOHELP
 #define WIN32_LEAN_AND_MEAN
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -71,6 +81,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/D3D12Test/pch.h
+++ b/D3D12Test/pch.h
@@ -27,6 +27,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -35,6 +41,10 @@
 #define NOSERVICE
 #define NOHELP
 #define WIN32_LEAN_AND_MEAN
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -70,6 +80,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/EffectsTest/Game.cpp
+++ b/EffectsTest/Game.cpp
@@ -28,26 +28,26 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const float rowA = -2.f;
-    const float row0 = 2.5f;
-    const float row1 = 1.5f;
-    const float row2 = 0.5f;
-    const float row3 = 0.f;
-    const float row4 = -0.5f;
-    const float row5 = -1.5f;
-    const float row6 = -2.5f;
+    constexpr float rowA = -2.f;
+    constexpr float row0 = 2.5f;
+    constexpr float row1 = 1.5f;
+    constexpr float row2 = 0.5f;
+    constexpr float row3 = 0.f;
+    constexpr float row4 = -0.5f;
+    constexpr float row5 = -1.5f;
+    constexpr float row6 = -2.5f;
 
-    const float colA = -5.f;
-    const float col0 = -4.f;
-    const float col1 = -3.f;
-    const float col2 = -2.f;
-    const float col3 = -1.f;
-    const float col4 = 0.f;
-    const float col5 = 1.f;
-    const float col6 = 2.f;
-    const float col7 = 3.f;
-    const float col8 = 4.f;
-    const float col9 = 5.f;
+    constexpr float colA = -5.f;
+    constexpr float col0 = -4.f;
+    constexpr float col1 = -3.f;
+    constexpr float col2 = -2.f;
+    constexpr float col3 = -1.f;
+    constexpr float col4 = 0.f;
+    constexpr float col5 = 1.f;
+    constexpr float col6 = 2.f;
+    constexpr float col7 = 3.f;
+    constexpr float col8 = 4.f;
+    constexpr float col9 = 5.f;
 
     struct TestVertex
     {
@@ -119,7 +119,7 @@ namespace
 
         for (int i = 0; i < 16; i++)
         {
-            controlPoints[i] = TeapotControlPoints[patch.indices[i]] * scale;
+            controlPoints[i] = XMVectorMultiply(TeapotControlPoints[patch.indices[i]], scale);
         }
 
         // Create the index data.
@@ -270,11 +270,11 @@ void Game::Render()
     float pitch = time * 0.7f;
     float roll = time * 1.1f;
 
-    XMVECTORF32 blue;
+    SimpleMath:: Vector4 blue;
 #ifdef GAMMA_CORRECT_RENDERING
-    blue.v = XMColorSRGBToRGB(Colors::Blue);
+    blue = XMColorSRGBToRGB(Colors::Blue);
 #else
-    blue.v = Colors::Blue;
+    blue = Colors::Blue;
 #endif
 
     XMMATRIX world = XMMatrixRotationRollPitchYaw(pitch, yaw, roll);
@@ -1131,7 +1131,7 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 cameraPosition = { 0, 0, 6 };
+    static const XMVECTORF32 cameraPosition = { { { 0.f, 0.f, 6.f, 0.f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;
@@ -1317,7 +1317,9 @@ void Game::CreateTeapot()
     VertexCollection vertices;
     IndexCollection indices;
 
-    for (int i = 0; i < sizeof(TeapotPatches) / sizeof(TeapotPatches[0]); i++)
+    XMVECTOR negateXZ = XMVectorMultiply(g_XMNegateX, g_XMNegateZ);
+
+    for (size_t i = 0; i < sizeof(TeapotPatches) / sizeof(TeapotPatches[0]); i++)
     {
         TeapotPatch const& patch = TeapotPatches[i];
 
@@ -1332,7 +1334,7 @@ void Game::CreateTeapot()
             // handle or spout) are also symmetrical from front to back, so
             // we tessellate them four times, mirroring in Z as well as X.
             TessellatePatch(vertices, indices, patch, g_XMNegateZ, true);
-            TessellatePatch(vertices, indices, patch, g_XMNegateX * g_XMNegateZ, false);
+            TessellatePatch(vertices, indices, patch, negateXZ, false);
         }
     }
 

--- a/EffectsTest/Game.cpp
+++ b/EffectsTest/Game.cpp
@@ -56,7 +56,7 @@ namespace
             XMStoreFloat3(&this->position, position);
             XMStoreFloat3(&this->normal, normal);
             XMStoreFloat2(&this->textureCoordinate, textureCoordinate);
-            XMStoreFloat2(&this->textureCoordinate2, textureCoordinate * 3);
+            XMStoreFloat2(&this->textureCoordinate2, XMVectorScale(textureCoordinate, 3.f));
             XMStoreUByte4(&this->blendIndices, XMVectorSet(0, 1, 2, 3));
 
             float u = XMVectorGetX(textureCoordinate) - 0.5f;

--- a/EffectsTest/pch.h
+++ b/EffectsTest/pch.h
@@ -19,6 +19,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -27,6 +33,10 @@
 #define NOSERVICE
 #define NOHELP
 #define WIN32_LEAN_AND_MEAN
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -62,6 +72,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 #include <DirectXPackedVector.h>

--- a/EmptyTest/pch.h
+++ b/EmptyTest/pch.h
@@ -27,6 +27,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -35,6 +41,10 @@
 #define NOSERVICE
 #define NOHELP
 #define WIN32_LEAN_AND_MEAN
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -70,6 +80,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/GamePadTest/Game.cpp
+++ b/GamePadTest/Game.cpp
@@ -31,8 +31,7 @@ using Microsoft::WRL::ComPtr;
 // Constructor.
 Game::Game() noexcept(false) :
     m_state{},
-    m_lastStr(nullptr),
-    m_lastStrBuff{}
+    m_lastStr(nullptr)
 {
 #ifdef GAMMA_CORRECT_RENDERING
     const DXGI_FORMAT c_RenderFormat = DXGI_FORMAT_B8G8R8A8_UNORM_SRGB;

--- a/GamePadTest/Game.h
+++ b/GamePadTest/Game.h
@@ -107,5 +107,4 @@ private:
     Microsoft::WRL::Wrappers::Event                 m_userChanged;
 
     const wchar_t *                                 m_lastStr;
-    wchar_t                                         m_lastStrBuff[128];
 };

--- a/GamePadTest/pch.h
+++ b/GamePadTest/pch.h
@@ -27,6 +27,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -35,6 +41,10 @@
 #define NOSERVICE
 #define NOHELP
 #define WIN32_LEAN_AND_MEAN
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -69,6 +79,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/HDRTest/Game.cpp
+++ b/HDRTest/Game.cpp
@@ -34,20 +34,20 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const XMVECTORF32 c_BrightYellow = { 2.f, 2.f, 0.f, 1.f };
+    constexpr XMVECTORF32 c_BrightYellow = { { { 2.f, 2.f, 0.f, 1.f } } };
 
-    const XMVECTORF32 c_DimWhite = { .5f, .5f, .5f, 1.f };
-    const XMVECTORF32 c_BrightWhite = { 2.f, 2.f, 2.f, 1.f };
-    const XMVECTORF32 c_VeryBrightWhite = { 4.f, 4.f, 4.f, 1.f };
+    constexpr XMVECTORF32 c_DimWhite = { { { .5f, .5f, .5f, 1.f } } };
+    constexpr XMVECTORF32 c_BrightWhite = { { { 2.f, 2.f, 2.f, 1.f } } };
+    constexpr XMVECTORF32 c_VeryBrightWhite = { { { 4.f, 4.f, 4.f, 1.f } } };
 
-    const float row0 = -2.f;
+    constexpr float row0 = -2.f;
 
-    const float col0 = -5.f;
-    const float col1 = -3.5f;
-    const float col2 = -1.f;
-    const float col3 = 1.f;
-    const float col4 = 3.5f;
-    const float col5 = 5.f;
+    constexpr float col0 = -5.f;
+    constexpr float col1 = -3.5f;
+    constexpr float col2 = -1.f;
+    constexpr float col3 = 1.f;
+    constexpr float col4 = 3.5f;
+    constexpr float col5 = 5.f;
 }
 
 #ifdef XBOX
@@ -56,7 +56,7 @@ extern bool g_HDRMode;
 
 Game::Game() noexcept(false)
 {
-#ifdef TEST_HDR_LINEAR
+#if defined(TEST_HDR_LINEAR) && !defined(XBOX)
     const DXGI_FORMAT c_DisplayFormat = DXGI_FORMAT_R16G16B16A16_FLOAT;
 #else
     const DXGI_FORMAT c_DisplayFormat = DXGI_FORMAT_R10G10B10A2_UNORM;
@@ -64,7 +64,7 @@ Game::Game() noexcept(false)
 
 #ifdef XBOX
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        DXGI_FORMAT_R10G10B10A2_UNORM, DXGI_FORMAT_D32_FLOAT, 2,
+        c_DisplayFormat, DXGI_FORMAT_D32_FLOAT, 2,
         DX::DeviceResources::c_Enable4K_UHD | DX::DeviceResources::c_EnableHDR);
 #elif defined(UWP)
     m_deviceResources = std::make_unique<DX::DeviceResources>(
@@ -144,12 +144,9 @@ void Game::Tick()
 }
 
 // Updates the world.
-void Game::Update(DX::StepTimer const& timer)
+void Game::Update(DX::StepTimer const&)
 {
     PIXBeginEvent(PIX_COLOR_DEFAULT, L"Update");
-
-    float elapsedTime = float(timer.GetElapsedSeconds());
-    elapsedTime;
 
     auto pad = m_gamePad->GetState(0);
     auto kb = m_keyboard->GetState();
@@ -239,7 +236,6 @@ void Game::Render()
     float roll = time * 1.1f;
 
     XMMATRIX world = XMMatrixRotationRollPitchYaw(pitch, yaw, roll);
-    XMVECTOR quat = XMQuaternionRotationRollPitchYaw(pitch, yaw, roll);
 
     m_flatEffect->SetMatrices(world* XMMatrixTranslation(col0, row0, 0), m_view, m_projection);
     m_flatEffect->SetTexture(hdrImage1, m_states->LinearWrap());
@@ -539,7 +535,7 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 cameraPosition = { 0, 0, 7 };
+    static const XMVECTORF32 cameraPosition = { { { 0.f, 0.f, 7.f, 0.f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;

--- a/HDRTest/pch.h
+++ b/HDRTest/pch.h
@@ -27,6 +27,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -35,6 +41,10 @@
 #define NOSERVICE
 #define NOHELP
 #define WIN32_LEAN_AND_MEAN
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -70,6 +80,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/KeyboardTest/Game.cpp
+++ b/KeyboardTest/Game.cpp
@@ -23,10 +23,10 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const XMVECTORF32 START_POSITION = { 0.f, -1.5f, 0.f, 0.f };
-    const XMVECTORF32 ROOM_BOUNDS = { 8.f, 6.f, 12.f, 0.f };
+    constexpr XMVECTORF32 START_POSITION = { { { 0.f, -1.5f, 0.f, 0.f } } };
+    constexpr XMVECTORF32 ROOM_BOUNDS = { { { 8.f, 6.f, 12.f, 0.f } } };
 
-    const float MOVEMENT_GAIN = 0.07f;
+    constexpr float MOVEMENT_GAIN = 0.07f;
 }
 
 Game::Game() noexcept(false) :
@@ -115,9 +115,6 @@ void Game::Initialize(
             throw std::exception("Keyboard not acting like a singleton");
 #endif
         }
-
-        auto state = Keyboard::Get().GetState();
-        state;
     }
 
     OutputDebugStringA(m_keyboard->IsConnected() ? "INFO: Keyboard is connected\n" : "INFO: No keyboard found\n");

--- a/KeyboardTest/pch.h
+++ b/KeyboardTest/pch.h
@@ -27,6 +27,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -35,6 +41,10 @@
 #define NOSERVICE
 #define NOHELP
 #define WIN32_LEAN_AND_MEAN
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -70,6 +80,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/LoadTest/Game.cpp
+++ b/LoadTest/Game.cpp
@@ -28,7 +28,7 @@
 
 namespace
 {
-    float dist = 10.f;
+    constexpr float dist = 10.f;
 };
 
 extern void ExitGame() noexcept;
@@ -146,12 +146,9 @@ void Game::Tick()
 }
 
 // Updates the world.
-void Game::Update(DX::StepTimer const& timer)
+void Game::Update(DX::StepTimer const&)
 {
     PIXBeginEvent(PIX_COLOR_DEFAULT, L"Update");
-
-    float elapsedTime = float(timer.GetElapsedSeconds());
-    elapsedTime;
 
     auto pad = m_gamePad->GetState(0);
     auto kb = m_keyboard->GetState();
@@ -405,7 +402,7 @@ void Game::Render()
             nullptr,
             [&](IPropertyBag2* props)
         {
-            PROPBAG2 options[2] = { 0, 0 };
+            PROPBAG2 options[2] = {};
             options[0].pstrName = const_cast<wchar_t*>(L"CompressionQuality");
             options[1].pstrName = const_cast<wchar_t*>(L"TiffCompressionMethod");
 
@@ -893,9 +890,9 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 eyePosition = { 0.0f, 3.0f, -6.0f, 0.0f };
-    static const XMVECTORF32 At = { 0.0f, 1.0f, 0.0f, 0.0f };
-    static const XMVECTORF32 Up = { 0.0f, 1.0f, 0.0f, 0.0f };
+    static const XMVECTORF32 eyePosition = { { { 0.0f, 3.0f, -6.0f, 0.0f } } };
+    static const XMVECTORF32 At = { { { 0.0f, 1.0f, 0.0f, 0.0f } } };
+    static const XMVECTORF32 Up = { { { 0.0f, 1.0f, 0.0f, 0.0f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;

--- a/LoadTest/pch.h
+++ b/LoadTest/pch.h
@@ -27,6 +27,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -35,6 +41,10 @@
 #define NOSERVICE
 #define NOHELP
 #define WIN32_LEAN_AND_MEAN
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -69,6 +79,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/ModelTest/Game.cpp
+++ b/ModelTest/Game.cpp
@@ -36,9 +36,9 @@ std::unique_ptr<Model> CreateModelFromOBJ(
 
 namespace
 {
-    const float row0 = 2.f;
-    const float row1 = 0.f;
-    const float row2 = -2.f;
+    constexpr float row0 = 2.f;
+    constexpr float row1 = 0.f;
+    constexpr float row2 = -2.f;
 }
 
 Game::Game() noexcept(false) :
@@ -920,7 +920,7 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 cameraPosition = { 0, 0, 6 };
+    static const XMVECTORF32 cameraPosition = { { { 0.f, 0.f, 6.f, 0.f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;

--- a/ModelTest/pch.h
+++ b/ModelTest/pch.h
@@ -27,6 +27,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -35,6 +41,10 @@
 #define NOSERVICE
 #define NOHELP
 #define WIN32_LEAN_AND_MEAN
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -70,6 +80,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/MouseTest/Game.cpp
+++ b/MouseTest/Game.cpp
@@ -23,10 +23,8 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const XMVECTORF32 START_POSITION = { 0.f, -1.5f, 0.f, 0.f };
-    const XMVECTORF32 ROOM_BOUNDS = { 8.f, 6.f, 12.f, 0.f };
-
-    const float MOVEMENT_GAIN = 0.07f;
+    constexpr XMVECTORF32 START_POSITION = { { { 0.f, -1.5f, 0.f, 0.f } } };
+    constexpr XMVECTORF32 ROOM_BOUNDS = { { { 8.f, 6.f, 12.f, 0.f } } };
 }
 
 Game::Game() noexcept(false) :
@@ -34,8 +32,7 @@ Game::Game() noexcept(false) :
     m_lastMode(Mouse::MODE_ABSOLUTE),
     m_pitch(0),
     m_yaw(0),
-    m_lastStr(nullptr),
-    m_lastStrBuff{}
+    m_lastStr(nullptr)
 {
     m_cameraPos = START_POSITION.v;
 
@@ -125,9 +122,6 @@ void Game::Initialize(
             throw std::exception("Mouse not acting like a singleton");
 #endif
         }
-
-        auto state = Mouse::Get().GetState();
-        state;
     }
 
     OutputDebugStringA(m_mouse->IsConnected() ? "INFO: Mouse is connected\n" : "INFO: No mouse found\n");
@@ -194,8 +188,8 @@ void Game::Update(DX::StepTimer const&)
 
     if (mouse.positionMode == Mouse::MODE_RELATIVE)
     {
-        static const XMVECTORF32 ROTATION_GAIN = { 0.004f, 0.004f, 0.f, 0.f };
-        XMVECTOR delta = XMVectorSet(float(mouse.x), float(mouse.y), 0.f, 0.f) * ROTATION_GAIN;
+        const SimpleMath::Vector4 ROTATION_GAIN(0.004f, 0.004f, 0.f, 0.f);
+        XMVECTOR delta = SimpleMath::Vector4(float(mouse.x), float(mouse.y), 0.f, 0.f) * ROTATION_GAIN;
 
         m_pitch -= XMVectorGetY(delta);
         m_yaw -= XMVectorGetX(delta);

--- a/MouseTest/Game.h
+++ b/MouseTest/Game.h
@@ -116,5 +116,4 @@ private:
     DirectX::SimpleMath::Vector3                        m_cameraPos;
 
     const wchar_t *                                     m_lastStr;
-    wchar_t                                             m_lastStrBuff[128];
 };

--- a/MouseTest/pch.h
+++ b/MouseTest/pch.h
@@ -27,6 +27,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -35,6 +41,10 @@
 #define NOSERVICE
 #define NOHELP
 #define WIN32_LEAN_AND_MEAN
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -70,6 +80,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/PBRModelTest/Game.cpp
+++ b/PBRModelTest/Game.cpp
@@ -27,9 +27,8 @@
 
 namespace
 {
-    const float row0 = 1.5f;
-    const float row1 = 0.f;
-    const float row2 = -1.5f;
+    constexpr float row0 = 1.5f;
+    constexpr float row1 = -1.5f;
 }
 
 extern void ExitGame() noexcept;
@@ -46,7 +45,7 @@ Game::Game() noexcept(false) :
     m_pitch(0),
     m_yaw(0)
 {
-#ifdef TEST_HDR_LINEAR
+#if defined(TEST_HDR_LINEAR) && !defined(XBOX)
     const DXGI_FORMAT c_DisplayFormat = DXGI_FORMAT_R16G16B16A16_FLOAT;
 #else
     const DXGI_FORMAT c_DisplayFormat = DXGI_FORMAT_R10G10B10A2_UNORM;
@@ -54,7 +53,7 @@ Game::Game() noexcept(false) :
 
 #ifdef XBOX
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        DXGI_FORMAT_R10G10B10A2_UNORM, DXGI_FORMAT_D32_FLOAT, 2,
+        c_DisplayFormat, DXGI_FORMAT_D32_FLOAT, 2,
         DX::DeviceResources::c_Enable4K_UHD | DX::DeviceResources::c_EnableHDR);
 #elif defined(UWP)
     m_deviceResources = std::make_unique<DX::DeviceResources>(
@@ -353,7 +352,7 @@ void Game::Render()
 
     {
         XMMATRIX scale = XMMatrixScaling(0.75f, 0.75f, 0.75f);
-        XMMATRIX trans = XMMatrixTranslation(-2.5f, row2, 0.f);
+        XMMATRIX trans = XMMatrixTranslation(-2.5f, row1, 0.f);
         local = XMMatrixMultiply(scale, trans);
         local = XMMatrixMultiply(world, local);
     }
@@ -362,7 +361,7 @@ void Game::Render()
 
     {
         XMMATRIX scale = XMMatrixScaling(0.1f, 0.1f, 0.1f);
-        XMMATRIX trans = XMMatrixTranslation(1.5f, row2, 0.f);
+        XMMATRIX trans = XMMatrixTranslation(1.5f, row1, 0.f);
         local = XMMatrixMultiply(scale, trans);
         local = XMMatrixMultiply(world, local);
     }
@@ -660,7 +659,7 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 cameraPosition = { 0, 0, 6 };
+    static const XMVECTORF32 cameraPosition = { { { 0.f, 0.f, 6.f, 0.f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;

--- a/PBRModelTest/pch.h
+++ b/PBRModelTest/pch.h
@@ -27,6 +27,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -35,6 +41,10 @@
 #define NOSERVICE
 #define NOHELP
 #define WIN32_LEAN_AND_MEAN
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -70,6 +80,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/PBRTest/Game.cpp
+++ b/PBRTest/Game.cpp
@@ -35,19 +35,19 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const float col0 = -4.25f;
-    const float col1 = -3.f;
-    const float col2 = -1.75f;
-    const float col3 = -.6f;
-    const float col4 = .6f;
-    const float col5 = 1.75f;
-    const float col6 = 3.f;
-    const float col7 = 4.25f;
+    constexpr float col0 = -4.25f;
+    constexpr float col1 = -3.f;
+    constexpr float col2 = -1.75f;
+    constexpr float col3 = -.6f;
+    constexpr float col4 = .6f;
+    constexpr float col5 = 1.75f;
+    constexpr float col6 = 3.f;
+    constexpr float col7 = 4.25f;
 
-    const float row0 = 2.f;
-    const float row1 = 0.25f;
-    const float row2 = -1.1f;
-    const float row3 = -2.5f;
+    constexpr float row0 = 2.f;
+    constexpr float row1 = 0.25f;
+    constexpr float row2 = -1.1f;
+    constexpr float row3 = -2.5f;
 
     void ReadVBO(_In_z_ const wchar_t* name, std::vector<VertexPositionNormalTexture>& vertices, std::vector<uint16_t>& indices)
     {
@@ -62,7 +62,7 @@ namespace
             if (!inFile)
                 throw std::exception("ReadVBO");
 
-            if (len < sizeof(VBO::header_t))
+            if (len < static_cast<std::streampos>(sizeof(VBO::header_t)))
                 throw std::exception("ReadVBO");
 
             blob.resize(size_t(len));
@@ -117,7 +117,7 @@ Game::Game() noexcept(false) :
     m_pitch(0),
     m_yaw(0)
 {
-#ifdef TEST_HDR_LINEAR
+#if defined(TEST_HDR_LINEAR) && !defined(XBOX)
     const DXGI_FORMAT c_DisplayFormat = DXGI_FORMAT_R16G16B16A16_FLOAT;
 #else
     const DXGI_FORMAT c_DisplayFormat = DXGI_FORMAT_R10G10B10A2_UNORM;
@@ -125,7 +125,7 @@ Game::Game() noexcept(false) :
 
 #ifdef XBOX
     m_deviceResources = std::make_unique<DX::DeviceResources>(
-        DXGI_FORMAT_R10G10B10A2_UNORM, DXGI_FORMAT_D32_FLOAT, 2,
+        c_DisplayFormat, DXGI_FORMAT_D32_FLOAT, 2,
         DX::DeviceResources::c_Enable4K_UHD | DX::DeviceResources::c_EnableHDR);
 #elif defined(UWP)
     m_deviceResources = std::make_unique<DX::DeviceResources>(
@@ -1036,7 +1036,7 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 cameraPosition = { 0, 0, 6 };
+    static const XMVECTORF32 cameraPosition = { { { 0.f, 0.f, 6.f, 0.f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;

--- a/PBRTest/pch.h
+++ b/PBRTest/pch.h
@@ -27,6 +27,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -35,6 +41,10 @@
 #define NOSERVICE
 #define NOHELP
 #define WIN32_LEAN_AND_MEAN
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -70,6 +80,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/PostProcessTest/Game.cpp
+++ b/PostProcessTest/Game.cpp
@@ -26,8 +26,8 @@ namespace
     constexpr float ADVANCE_TIME = 1.f;
     constexpr float INTERACTIVE_TIME = 10.f;
 
-    const DXGI_FORMAT c_sdrFormat = DXGI_FORMAT_R10G10B10A2_UNORM;
-    const DXGI_FORMAT c_hdrFormat = DXGI_FORMAT_R16G16B16A16_FLOAT;
+    constexpr DXGI_FORMAT c_sdrFormat = DXGI_FORMAT_R10G10B10A2_UNORM;
+    constexpr DXGI_FORMAT c_hdrFormat = DXGI_FORMAT_R16G16B16A16_FLOAT;
 }
 
 Game::Game() noexcept(false)  :
@@ -976,7 +976,7 @@ void Game::CreateDeviceDependentResources()
         m_dualPostProcess[j] = std::make_unique<DualPostProcess>(device, rtState, static_cast<DualPostProcess::Effect>(j));
     }
 
-    int j = 0;
+    size_t j = 0;
 #ifdef XBOX
     for (int m = 0; m < 2; ++m)
 #else
@@ -1020,7 +1020,7 @@ void Game::CreateWindowSizeDependentResources()
             width, height,
             1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET);
 
-        D3D12_CLEAR_VALUE clearValue = { c_hdrFormat };
+        D3D12_CLEAR_VALUE clearValue = { c_hdrFormat, {} };
         memcpy(clearValue.Color, Colors::CornflowerBlue.f, sizeof(clearValue.Color));
 
         DX::ThrowIfFailed(
@@ -1041,7 +1041,7 @@ void Game::CreateWindowSizeDependentResources()
             width, height,
             1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET);
 
-        D3D12_CLEAR_VALUE clearValue = { c_sdrFormat };
+        D3D12_CLEAR_VALUE clearValue = { c_sdrFormat, {} };
         memcpy(clearValue.Color, Colors::CornflowerBlue.f, sizeof(clearValue.Color));
 
         DX::ThrowIfFailed(

--- a/PostProcessTest/pch.h
+++ b/PostProcessTest/pch.h
@@ -27,6 +27,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -35,6 +41,10 @@
 #define NOSERVICE
 #define NOHELP
 #define WIN32_LEAN_AND_MEAN
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -70,6 +80,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/PrimitivesTest/Game.cpp
+++ b/PrimitivesTest/Game.cpp
@@ -21,22 +21,22 @@
 
 namespace
 {
-    const float row0 = 2.7f;
-    const float row1 = 1.f;
-    const float row2 = -0.7f;
-    const float row3 = -2.5f;
+    constexpr float row0 = 2.7f;
+    constexpr float row1 = 1.f;
+    constexpr float row2 = -0.7f;
+    constexpr float row3 = -2.5f;
 
-    const float col0 = -7.5f;
-    const float col1 = -5.75f;
-    const float col2 = -4.25f;
-    const float col3 = -2.7f;
-    const float col4 = -1.25f;
-    const float col5 = 0.f;
-    const float col6 = 1.25f;
-    const float col7 = 2.5f;
-    const float col8 = 4.25f;
-    const float col9 = 5.75f;
-    const float col10 = 7.5f;
+    constexpr float col0 = -7.5f;
+    constexpr float col1 = -5.75f;
+    constexpr float col2 = -4.25f;
+    constexpr float col3 = -2.7f;
+    constexpr float col4 = -1.25f;
+    constexpr float col5 = 0.f;
+    constexpr float col6 = 1.25f;
+    constexpr float col7 = 2.5f;
+    constexpr float col8 = 4.25f;
+    constexpr float col9 = 5.75f;
+    constexpr float col10 = 7.5f;
 }
 
 extern void ExitGame() noexcept;
@@ -299,6 +299,7 @@ void Game::Render()
     lime.v = Colors::Lime;
     gray.v = Colors::Gray;
 #endif
+    SimpleMath::Vector4 white = Colors::White.v;
 
     // Draw shapes.
     m_effect->SetWorld(world * XMMatrixTranslation(col0, row0, 0));
@@ -480,21 +481,21 @@ void Game::Render()
 
     // Draw shapes with alpha blending.
     m_effectAlpha->SetWorld(world * XMMatrixTranslation(col0, row3, 0));
-    m_effectAlpha->SetDiffuseColor(Colors::White * alphaFade);
+    m_effectAlpha->SetDiffuseColor(white * alphaFade);
     m_effectAlpha->SetAlpha(alphaFade);
     m_effectAlpha->Apply(commandList);
     m_cube->Draw(commandList);
 
     m_effectPMAlphaTexture->SetTexture(m_resourceDescriptors->GetGpuHandle(Descriptors::Cat), m_states->AnisotropicWrap());
     m_effectPMAlphaTexture->SetWorld(world * XMMatrixTranslation(col1, row3, 0));
-    m_effectPMAlphaTexture->SetDiffuseColor(Colors::White * alphaFade);
+    m_effectPMAlphaTexture->SetDiffuseColor(white * alphaFade);
     m_effectPMAlphaTexture->SetAlpha(alphaFade);
     m_effectPMAlphaTexture->Apply(commandList);
     m_cube->Draw(commandList);
 
     m_effectAlphaTexture->SetTexture(m_resourceDescriptors->GetGpuHandle(Descriptors::Cat), m_states->AnisotropicWrap());
     m_effectAlphaTexture->SetWorld(world * XMMatrixTranslation(col2, row3, 0));
-    m_effectAlphaTexture->SetDiffuseColor(Colors::White * alphaFade);
+    m_effectAlphaTexture->SetDiffuseColor(white * alphaFade);
     m_effectAlphaTexture->SetAlpha(alphaFade);
     m_effectAlphaTexture->Apply(commandList);
     m_cube->Draw(commandList);
@@ -912,7 +913,7 @@ void Game::CreateDeviceDependentResources()
 // Allocate all memory resources that change on a window SizeChanged event.
 void Game::CreateWindowSizeDependentResources()
 {
-    static const XMVECTORF32 cameraPosition = { 0, 0, 9 };
+    static const XMVECTORF32 cameraPosition = { { { 0.f, 0.f, 9.f, 0.f } } };
 
     auto size = m_deviceResources->GetOutputSize();
     float aspect = (float)size.right / (float)size.bottom;

--- a/PrimitivesTest/pch.h
+++ b/PrimitivesTest/pch.h
@@ -27,6 +27,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -35,6 +41,10 @@
 #define NOSERVICE
 #define NOHELP
 #define WIN32_LEAN_AND_MEAN
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -70,6 +80,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 
@@ -93,6 +104,7 @@
 #include "Mouse.h"
 #include "RenderTargetState.h"
 #include "ResourceUploadBatch.h"
+#include "SimpleMath.h"
 
 namespace DX
 {

--- a/ShaderTest/Game.cpp
+++ b/ShaderTest/Game.cpp
@@ -37,7 +37,7 @@ namespace
             XMStoreFloat3(&this->position, position);
             XMStoreFloat3(&this->normal, normal);
             XMStoreFloat2(&this->textureCoordinate, textureCoordinate);
-            XMStoreFloat2(&this->textureCoordinate2, textureCoordinate * 3);
+            XMStoreFloat2(&this->textureCoordinate2, XMVectorScale(textureCoordinate, 3.f));
             XMStoreUByte4(&this->blendIndices, XMVectorSet(0, 0, 0, 0));
 
             XMStoreFloat4(&this->blendWeight, XMVectorSet(1.f, 0.f, 0.f, 0.f));

--- a/ShaderTest/Game.cpp
+++ b/ShaderTest/Game.cpp
@@ -1627,7 +1627,7 @@ void Game::CreateCube()
     const Vector4 tsize(0.25f, 0.25f, 0.25f, 0.f);
 
     // Create each face in turn.
-    for (int i = 0; i < FaceCount; i++)
+    for (size_t i = 0; i < FaceCount; i++)
     {
         Vector4 normal = faceNormals[i].v;
 

--- a/ShaderTest/Game.cpp
+++ b/ShaderTest/Game.cpp
@@ -27,8 +27,8 @@ namespace
     constexpr float SWAP_TIME = 1.f;
     constexpr float INTERACTIVE_TIME = 10.f;
 
-    const float ortho_width = 6.f;
-    const float ortho_height = 6.f;
+    constexpr float ortho_width = 6.f;
+    constexpr float ortho_height = 6.f;
 
     struct TestVertex
     {
@@ -89,8 +89,7 @@ namespace
             blendIndices = bn.blendIndices;
 
             XMVECTOR v = XMLoadFloat3(&bn.normal);
-            v = v * g_XMOneHalf;
-            v += g_XMOneHalf;
+            v = XMVectorMultiplyAdd(v, g_XMOneHalf, g_XMOneHalf);
             XMStoreFloat3PK(&this->normal, v);
 
             v = XMLoadFloat2(&bn.textureCoordinate);
@@ -236,9 +235,6 @@ void Game::Tick()
 void Game::Update(DX::StepTimer const& timer)
 {
     PIXBeginEvent(PIX_COLOR_DEFAULT, L"Update");
-
-    float elapsedTime = float(timer.GetElapsedSeconds());
-    elapsedTime;
 
     auto pad = m_gamePad->GetState(0);
     auto kb = m_keyboard->GetState();
@@ -1602,20 +1598,20 @@ void Game::CreateCube()
 
     static const XMVECTORF32 faceNormals[FaceCount] =
     {
-        { 0,  0,  1 },
-        { 0,  0, -1 },
-        { 1,  0,  0 },
-        { -1,  0,  0 },
-        { 0,  1,  0 },
-        { 0, -1,  0 },
+        { { { 0,  0,  1, 0 } } },
+        { { { 0,  0, -1, 0 } } },
+        { { { 1,  0,  0, 0 } } },
+        { { { -1,  0,  0, 0 } } },
+        { { { 0,  1,  0, 0 } } },
+        { { { 0, -1,  0, 0 } } },
     };
 
     static const XMVECTORF32 textureCoordinates[4] =
     {
-        { 1, 0 },
-        { 1, 1 },
-        { 0, 1 },
-        { 0, 0 },
+        { { { 1, 0, 0, 0 } } },
+        { { { 1, 1, 0, 0 } } },
+        { { { 0, 1, 0, 0 } } },
+        { { { 0, 0, 0, 0 } } },
     };
 
     static uint32_t colors[FaceCount]
@@ -1628,18 +1624,18 @@ void Game::CreateCube()
         0xFF00FFFF,
     };
 
-    static const XMVECTORF32 tsize = { 0.25f, 0.25f, 0.25f, 0.f };
+    const Vector4 tsize(0.25f, 0.25f, 0.25f, 0.f);
 
     // Create each face in turn.
     for (int i = 0; i < FaceCount; i++)
     {
-        XMVECTOR normal = faceNormals[i];
+        Vector4 normal = faceNormals[i].v;
 
         // Get two vectors perpendicular both to the face normal and to each other.
         XMVECTOR basis = (i >= 4) ? g_XMIdentityR2 : g_XMIdentityR1;
 
-        XMVECTOR side1 = XMVector3Cross(normal, basis);
-        XMVECTOR side2 = XMVector3Cross(normal, side1);
+        Vector4 side1 = XMVector3Cross(normal, basis);
+        Vector4 side2 = XMVector3Cross(normal, side1);
 
         // Six indices (two triangles) per face.
         size_t vbase = vertices.size();

--- a/ShaderTest/pch.h
+++ b/ShaderTest/pch.h
@@ -27,6 +27,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -70,6 +76,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXPackedVector.h>
 #include <DirectXColors.h>

--- a/SimpleAudioTest/Game.cpp
+++ b/SimpleAudioTest/Game.cpp
@@ -24,8 +24,8 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    const unsigned int WB_INMEMORY_ENTRY = 8;
-    const unsigned int WB_STREAM_ENTRY = 1;
+    constexpr unsigned int WB_INMEMORY_ENTRY = 8;
+    constexpr unsigned int WB_STREAM_ENTRY = 1;
 
     const wchar_t* STREAM_NAMES[] =
     {
@@ -124,7 +124,7 @@ namespace
             }
             else
             {
-                static const GUID s_wfexBase = { 0x00000000, 0x0000, 0x0010, 0x80, 0x00, 0x00, 0xAA, 0x00, 0x38, 0x9B, 0x71 };
+                static const GUID s_wfexBase = { 0x00000000, 0x0000, 0x0010, { 0x80, 0x00, 0x00, 0xAA, 0x00, 0x38, 0x9B, 0x71 } };
 
                 auto wfex = reinterpret_cast<const WAVEFORMATEXTENSIBLE*>(wfx);
 

--- a/SimpleAudioTest/pch.h
+++ b/SimpleAudioTest/pch.h
@@ -27,6 +27,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -35,6 +41,10 @@
 #define NOSERVICE
 #define NOHELP
 #define WIN32_LEAN_AND_MEAN
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -71,6 +81,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/SpriteBatchTest/Game.cpp
+++ b/SpriteBatchTest/Game.cpp
@@ -113,12 +113,9 @@ void Game::Tick()
 }
 
 // Updates the world.
-void Game::Update(DX::StepTimer const& timer)
+void Game::Update(DX::StepTimer const&)
 {
     PIXBeginEvent(PIX_COLOR_DEFAULT, L"Update");
-
-    float elapsedTime = float(timer.GetElapsedSeconds());
-    elapsedTime;
 
     auto pad = m_gamePad->GetState(0);
     auto kb = m_keyboard->GetState();

--- a/SpriteBatchTest/pch.h
+++ b/SpriteBatchTest/pch.h
@@ -27,6 +27,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -70,6 +76,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/SpriteFontTest/Game.cpp
+++ b/SpriteFontTest/Game.cpp
@@ -254,11 +254,11 @@ void Game::Render()
 
         float scale = sin(time / 100) + 1;
         auto spinText = "Spinning\nlike a cat";
-        auto size = m_comicFont->MeasureString(spinText);
+        SimpleMath::Vector2 size = m_comicFont->MeasureString(spinText);
         m_comicFont->DrawString(m_spriteBatch.get(), spinText, XMVectorSet(150, 350, 0, 0), blue, time / 60, size / 2, scale);
 
         auto mirrorText = "It's a\nmirror...";
-        auto mirrorSize = m_comicFont->MeasureString(mirrorText);
+        SimpleMath::Vector2 mirrorSize = m_comicFont->MeasureString(mirrorText);
         m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), Colors::Black, 0, mirrorSize * XMVectorSet(0, 1, 0, 0), 1, SpriteEffects_None);
         m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), gray, 0, mirrorSize * XMVectorSet(1, 1, 0, 0), 1, SpriteEffects_FlipHorizontally);
         m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), gray, 0, mirrorSize * XMVectorSet(0, 0, 0, 0), 1, SpriteEffects_FlipVertically);
@@ -286,11 +286,11 @@ void Game::Render()
 
         float scale = sin(time / 100) + 1;
         auto spinText = L"Spinning\nlike a cat";
-        auto size = m_comicFont->MeasureString(spinText);
+        SimpleMath::Vector2 size = m_comicFont->MeasureString(spinText);
         m_comicFont->DrawString(m_spriteBatch.get(), spinText, XMVectorSet(150, 350, 0, 0), blue, time / 60, size / 2, scale);
 
         auto mirrorText = L"It's a\nmirror...";
-        auto mirrorSize = m_comicFont->MeasureString(mirrorText);
+        SimpleMath::Vector2 mirrorSize = m_comicFont->MeasureString(mirrorText);
         m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), Colors::Black, 0, mirrorSize * XMVectorSet(0, 1, 0, 0), 1, SpriteEffects_None);
         m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), gray, 0, mirrorSize * XMVectorSet(1, 1, 0, 0), 1, SpriteEffects_FlipHorizontally);
         m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), gray, 0, mirrorSize * XMVectorSet(0, 0, 0, 0), 1, SpriteEffects_FlipVertically);

--- a/SpriteFontTest/Game.cpp
+++ b/SpriteFontTest/Game.cpp
@@ -31,6 +31,7 @@ namespace
 extern void ExitGame() noexcept;
 
 using namespace DirectX;
+using namespace DirectX::SimpleMath;
 
 using Microsoft::WRL::ComPtr;
 
@@ -254,15 +255,15 @@ void Game::Render()
 
         float scale = sin(time / 100) + 1;
         auto spinText = "Spinning\nlike a cat";
-        SimpleMath::Vector2 size = m_comicFont->MeasureString(spinText);
-        m_comicFont->DrawString(m_spriteBatch.get(), spinText, XMVectorSet(150, 350, 0, 0), blue, time / 60, size / 2, scale);
+        Vector2 size = m_comicFont->MeasureString(spinText);
+        m_comicFont->DrawString(m_spriteBatch.get(), spinText, Vector2(150, 350), blue, time / 60, size / 2, scale);
 
         auto mirrorText = "It's a\nmirror...";
-        SimpleMath::Vector2 mirrorSize = m_comicFont->MeasureString(mirrorText);
-        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), Colors::Black, 0, mirrorSize * XMVectorSet(0, 1, 0, 0), 1, SpriteEffects_None);
-        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), gray, 0, mirrorSize * XMVectorSet(1, 1, 0, 0), 1, SpriteEffects_FlipHorizontally);
-        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), gray, 0, mirrorSize * XMVectorSet(0, 0, 0, 0), 1, SpriteEffects_FlipVertically);
-        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), dgray, 0, mirrorSize * XMVectorSet(1, 0, 0, 0), 1, SpriteEffects_FlipBoth);
+        Vector2 mirrorSize = m_comicFont->MeasureString(mirrorText);
+        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, Vector2(400, 400), Colors::Black, 0, mirrorSize * Vector2(0, 1), 1, SpriteEffects_None);
+        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, Vector2(400, 400), gray, 0, mirrorSize * Vector2(1, 1), 1, SpriteEffects_FlipHorizontally);
+        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, Vector2(400, 400), gray, 0, mirrorSize * Vector2(0, 0), 1, SpriteEffects_FlipVertically);
+        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, Vector2(400, 400), dgray, 0, mirrorSize * Vector2(1, 0), 1, SpriteEffects_FlipBoth);
 
         m_japaneseFont->DrawString(m_spriteBatch.get(), L"\x79C1\x306F\x65E5\x672C\x8A9E\x304C\x8A71\x305B\x306A\x3044\x306E\x3067\x3001\n\x79C1\x306F\x3053\x308C\x304C\x4F55\x3092\x610F\x5473\x3059\x308B\x306E\x304B\x308F\x304B\x308A\x307E\x305B\x3093", XMFLOAT2(10, 512));
     }
@@ -286,15 +287,15 @@ void Game::Render()
 
         float scale = sin(time / 100) + 1;
         auto spinText = L"Spinning\nlike a cat";
-        SimpleMath::Vector2 size = m_comicFont->MeasureString(spinText);
-        m_comicFont->DrawString(m_spriteBatch.get(), spinText, XMVectorSet(150, 350, 0, 0), blue, time / 60, size / 2, scale);
+        Vector2 size = m_comicFont->MeasureString(spinText);
+        m_comicFont->DrawString(m_spriteBatch.get(), spinText, Vector2(150, 350), blue, time / 60, size / 2, scale);
 
         auto mirrorText = L"It's a\nmirror...";
-        SimpleMath::Vector2 mirrorSize = m_comicFont->MeasureString(mirrorText);
-        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), Colors::Black, 0, mirrorSize * XMVectorSet(0, 1, 0, 0), 1, SpriteEffects_None);
-        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), gray, 0, mirrorSize * XMVectorSet(1, 1, 0, 0), 1, SpriteEffects_FlipHorizontally);
-        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), gray, 0, mirrorSize * XMVectorSet(0, 0, 0, 0), 1, SpriteEffects_FlipVertically);
-        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), dgray, 0, mirrorSize * XMVectorSet(1, 0, 0, 0), 1, SpriteEffects_FlipBoth);
+        Vector2 mirrorSize = m_comicFont->MeasureString(mirrorText);
+        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, Vector2(400, 400), Colors::Black, 0, mirrorSize * Vector2(0, 1), 1, SpriteEffects_None);
+        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, Vector2(400, 400), gray, 0, mirrorSize * Vector2(1, 1), 1, SpriteEffects_FlipHorizontally);
+        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, Vector2(400, 400), gray, 0, mirrorSize * Vector2(0, 0), 1, SpriteEffects_FlipVertically);
+        m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, Vector2(400, 400), dgray, 0, mirrorSize * Vector2(1, 0), 1, SpriteEffects_FlipBoth);
 
         m_japaneseFont->DrawString(m_spriteBatch.get(), L"\x79C1\x306F\x65E5\x672C\x8A9E\x304C\x8A71\x305B\x306A\x3044\x306E\x3067\x3001\n\x79C1\x306F\x3053\x308C\x304C\x4F55\x3092\x610F\x5473\x3059\x308B\x306E\x304B\x308F\x304B\x308A\x307E\x305B\x3093", XMFLOAT2(10, 512));
     }

--- a/SpriteFontTest/Game.cpp
+++ b/SpriteFontTest/Game.cpp
@@ -23,9 +23,9 @@
 
 namespace
 {
-    const float SWAP_TIME = 3.f;
+    constexpr float SWAP_TIME = 3.f;
 
-    const float EPSILON = 0.000001f;
+    constexpr float EPSILON = 0.000001f;
 }
 
 extern void ExitGame() noexcept;
@@ -243,7 +243,7 @@ void Game::Render()
         SpriteEffects flip = (SpriteEffects)((int)(time / 100) & 3);
         m_multicoloredFont->DrawString(m_spriteBatch.get(), "OMG it's full of stars!", XMFLOAT2(610, 130), Colors::White, XM_PIDIV2, XMFLOAT2(0, 0), 1, flip);
 
-        m_comicFont->DrawString(m_spriteBatch.get(), u8"This is a larger block\nof text using a\nfont scaled to a\nsmaller size.\nSome c\x1234ha\x1543rac\x2453te\x1634r\x1563s are not in the font, but should show up as hyphens.", XMFLOAT2(10, 90), Colors::Black, 0, XMFLOAT2(0, 0), 0.5f);
+        m_comicFont->DrawString(m_spriteBatch.get(), u8"This is a larger block\nof text using a\nfont scaled to a\nsmaller size.\nSome c\xffha\xferac\xfdte\xffr\xfas are not in the font, but should show up as hyphens.", XMFLOAT2(10, 90), Colors::Black, 0, XMFLOAT2(0, 0), 0.5f);
 
         char tmp[256] = {};
         sprintf_s(tmp, "%llu frames", m_frame);
@@ -264,7 +264,7 @@ void Game::Render()
         m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), gray, 0, mirrorSize * XMVectorSet(0, 0, 0, 0), 1, SpriteEffects_FlipVertically);
         m_comicFont->DrawString(m_spriteBatch.get(), mirrorText, XMVectorSet(400, 400, 0, 0), dgray, 0, mirrorSize * XMVectorSet(1, 0, 0, 0), 1, SpriteEffects_FlipBoth);
 
-        m_japaneseFont->DrawString(m_spriteBatch.get(), u8"\x79C1\x306F\x65E5\x672C\x8A9E\x304C\x8A71\x305B\x306A\x3044\x306E\x3067\x3001\n\x79C1\x306F\x3053\x308C\x304C\x4F55\x3092\x610F\x5473\x3059\x308B\x306E\x304B\x308F\x304B\x308A\x307E\x305B\x3093", XMFLOAT2(10, 512));
+        m_japaneseFont->DrawString(m_spriteBatch.get(), L"\x79C1\x306F\x65E5\x672C\x8A9E\x304C\x8A71\x305B\x306A\x3044\x306E\x3067\x3001\n\x79C1\x306F\x3053\x308C\x304C\x4F55\x3092\x610F\x5473\x3059\x308B\x306E\x304B\x308F\x304B\x308A\x307E\x305B\x3093", XMFLOAT2(10, 512));
     }
     else
     {

--- a/SpriteFontTest/pch.h
+++ b/SpriteFontTest/pch.h
@@ -27,6 +27,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -35,6 +41,10 @@
 #define NOSERVICE
 #define NOHELP
 #define WIN32_LEAN_AND_MEAN
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -70,6 +80,7 @@
 #include "d3dx12.h"
 #endif
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 

--- a/SpriteFontTest/pch.h
+++ b/SpriteFontTest/pch.h
@@ -98,6 +98,7 @@
 #include "Keyboard.h"
 #include "Mouse.h"
 #include "ResourceUploadBatch.h"
+#include "SimpleMath.h"
 #include "SpriteFont.h"
 
 namespace DX

--- a/mGPUTest/pch.h
+++ b/mGPUTest/pch.h
@@ -25,6 +25,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4005)
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
 #define NOMINMAX
 #define NODRAWTEXT
 #define NOGDI
@@ -33,6 +39,10 @@
 #define NOSERVICE
 #define NOHELP
 #define WIN32_LEAN_AND_MEAN
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #pragma warning(pop)
 
 #define _CRTDBG_MAP_ALLOC
@@ -60,6 +70,7 @@
 #define D3DX12_NO_STATE_OBJECT_HELPERS
 #include "d3dx12.h"
 
+#define _XM_NO_XMVECTOR_OVERLOADS_
 #include <DirectXMath.h>
 #include <DirectXColors.h>
 


### PR DESCRIPTION
Mostly changes related to using ``_XM_NO_XMVECTOR_OVERLOADS_`` for DirectXMath, plus some warnings